### PR TITLE
chore: remove prometheus metrics from s3

### DIFF
--- a/apps/tenant-s3/values/prod.yaml
+++ b/apps/tenant-s3/values/prod.yaml
@@ -61,5 +61,5 @@ tenant:
   users:
     - name: tenant-s3-minio-admin-console-user-credentials
   metrics:
-    enabled: true
-  prometheusOperator: true
+    enabled: false
+  prometheusOperator: false


### PR DESCRIPTION
## Description
<!-- Brief description of what this PR does and why it's needed -->

## Type of Change
- [ ] New Application/Chart
- [X] Configuration Update
- [ ] Version Upgrade
- [ ] Bug Fix
- [ ] Other (please describe)

## Testing Performed
<!-- Describe how you tested these changes -->

## Impact Assessment
- [ ] Zero downtime expected
- [X] Brief service interruption expected
- [ ] Requires manual intervention after deployment

## Checklist
- [ ] Changes follow repository standards and conventions
- [ ] Values files are properly configured
- [ ] Helm chart versions are explicitly set
- [ ] Documentation has been updated (if applicable)
- [ ] Dry-run/validation performed locally

## Additional Context
<!-- Add any other relevant information, screenshots, or links here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled metrics collection and Prometheus operator integration in production environment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->